### PR TITLE
Add specific test CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
     - "node"
+    - "8"
+    - "6"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "babel lib -d dist",
     "prepublish": "npm run build",
-    "test": "node_modules/mocha/bin/mocha test test/"
+    "test": "mocha --compilers js:babel-core/register test test/"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.4.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
The current problem with only using `node` as CI target, that tests are run only on the latest node (e.g. 9.4.0). By defining specific versions backwards compatibility can be ensured.